### PR TITLE
Allow for custom chassis id

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,6 +4,7 @@ import store from '../store/index';
 import AppLayout from '../layouts/AppLayout.vue';
 import LoginLayout from '@/layouts/LoginLayout';
 import ConsoleLayout from '@/layouts/ConsoleLayout.vue';
+import api from '../store/api';
 
 Vue.use(VueRouter);
 
@@ -213,6 +214,9 @@ const router = new VueRouter({
 });
 
 router.beforeEach((to, from, next) => {
+  api.clearCache();
+  api.enableCache();
+
   if (to.matched.some(record => record.meta.requiresAuth)) {
     if (store.getters['authentication/isLoggedIn']) {
       next();
@@ -222,6 +226,10 @@ router.beforeEach((to, from, next) => {
   } else {
     next();
   }
+});
+
+router.afterEach(() => {
+  api.disableCache();
 });
 
 export default router;

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -32,9 +32,22 @@ api.interceptors.response.use(undefined, error => {
   return Promise.reject(error);
 });
 
+let cache = {};
+let cacheEnabled = false;
+
 export default {
   get(path) {
-    return api.get(path);
+    if (cacheEnabled && cache[path]) {
+      return cache[path];
+    }
+
+    const responsePromise = api.get(path);
+
+    if (cacheEnabled) {
+      cache[path] = responsePromise;
+    }
+
+    return responsePromise;
   },
   delete(path, payload) {
     return api.delete(path, payload);
@@ -53,6 +66,15 @@ export default {
   },
   spread(callback) {
     return Axios.spread(callback);
+  },
+  clearCache() {
+    cache = {};
+  },
+  enableCache() {
+    cacheEnabled = true;
+  },
+  disableCache() {
+    cacheEnabled = false;
   }
 };
 

--- a/src/store/modules/Control/PowerControlStore.js
+++ b/src/store/modules/Control/PowerControlStore.js
@@ -22,37 +22,40 @@ const PowerControlStore = {
       commit('setPowerCapValue', value);
     },
     async getPowerControl({ commit }) {
-      return await api
-        .get('/redfish/v1/Chassis/chassis/Power')
-        .then(response => {
-          const powerControl = response.data.PowerControl;
-          const powerCap = powerControl[0].PowerLimit.LimitInWatts;
-          // If system is powered off, power consumption does not exist in the PowerControl
-          const powerConsumption = powerControl[0].PowerConsumedWatts || null;
+      try {
+        const { data } = await api.get('/redfish/v1/Chassis');
+        const chassisId = data.Members[0]['@odata.id'].split('/').pop();
 
-          commit('setPowerCapValue', powerCap);
-          commit('setPowerConsumptionValue', powerConsumption);
-        })
-        .catch(error => {
-          console.log('Power control', error);
-        });
+        const response = await api.get(
+          `/redfish/v1/Chassis/${chassisId}/Power`
+        );
+        const powerControl = response.data.PowerControl;
+        const powerCap = powerControl[0].PowerLimit.LimitInWatts;
+        // If system is powered off, power consumption does not exist in the PowerControl
+        const powerConsumption = powerControl[0].PowerConsumedWatts || null;
+
+        commit('setPowerCapValue', powerCap);
+        commit('setPowerConsumptionValue', powerConsumption);
+      } catch (error) {
+        console.log('Power control', error);
+      }
     },
     async setPowerControl(_, powerCapValue) {
-      const data = {
-        PowerControl: [{ PowerLimit: { LimitInWatts: powerCapValue } }]
-      };
+      const { data } = await api.get('/redfish/v1/Chassis');
+      const chassisId = data.Members[0]['@odata.id'].split('/').pop();
 
-      return await api
-        .patch('/redfish/v1/Chassis/chassis/Power', data)
-        .then(() =>
-          i18n.t('pageServerPowerOperations.toast.successSaveSettings')
-        )
-        .catch(error => {
-          console.log(error);
-          throw new Error(
-            i18n.t('pageServerPowerOperations.toast.errorSaveSettings')
-          );
-        });
+      try {
+        const data = {
+          PowerControl: [{ PowerLimit: { LimitInWatts: powerCapValue } }]
+        };
+        await api.patch(`/redfish/v1/Chassis/${chassisId}/Power`, data);
+        i18n.t('pageServerPowerOperations.toast.successSaveSettings');
+      } catch (error) {
+        console.log(error);
+        throw new Error(
+          i18n.t('pageServerPowerOperations.toast.errorSaveSettings')
+        );
+      }
     }
   }
 };


### PR DESCRIPTION
Hello!

I'd like to add support for non-openbmc custom resource names (for example Chassis is named `System.Embedded.1` in my iDRAC8 redfish API). Here I'm presenting one solution and I'd love to hear a feedback if this approach would suit you, and if not, what would you suggest?

I think few things need to be ensured:
- If multiple modules on the same page (e.g. overview) need the same resource id / info, we should only fetch it once (in this PR I use temporary caching on API level to achieve this, REST is perfect for this)
- We should only fetch as many resource names as necessary (for example if on given screen we need to only access chassis info, we don't need to fetch names of managers etc.). This PR achieves it by fetching resource id in action that uses this resource id, instead of in GlobalStore.

The caching behavior can be improved in the future so chassis id is not re-fetched if page is refreshed.

If you like this approach I can submit PR for other modules