### PR TITLE
Fix unit data inconsistencies

### DIFF
--- a/src/store/modules/HardwareStatus/SensorsStore.js
+++ b/src/store/modules/HardwareStatus/SensorsStore.js
@@ -65,7 +65,10 @@ const SensorsStore = {
               upperCaution: response.data.Thresholds?.UpperCaution?.Reading,
               lowerCritical: response.data.Thresholds?.LowerCritical?.Reading,
               upperCritical: response.data.Thresholds?.UpperCritical?.Reading,
-              units: response.data.ReadingUnits,
+              units:
+                response.data.ReadingUnits === 'Cel'
+                  ? '℃'
+                  : response.data.ReadingUnits,
             });
           }
         });


### PR DESCRIPTION
Issue: In the sensors page of the webui , the unit displayed for the temperature sensor is not the set '°C ', but the 'Cel'.
Cause: Caused by differences in data sources.
Solution: Unify all temperature units.